### PR TITLE
Records - gcc arm target removal

### DIFF
--- a/records/tools/make_gcc_arm.yaml
+++ b/records/tools/make_gcc_arm.yaml
@@ -1,7 +1,3 @@
-common:
-    target:
-        - cortex-m0
-
 tool_specific:
     make_gcc_arm:
         mcu:


### PR DESCRIPTION
This should fix the targets overwrite to cortex m0