### PR TITLE
Fix ability to pass in custom value ram address for blob start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Skip any step where a compatible tool already exists
 > git clone https://github.com/mbedmicro/DAPLink
 > pip install virtualenv
 > virtualenv venv
-> 
+>
 ```
 
 ## Develop
@@ -25,6 +25,9 @@ Skip any step where a compatible tool already exists
 > "venv/Scripts/deactivate"
 ```
 
+To change the RAM base address to something other than the default value of 0x20000000, add the argument  --blob_start 0x[RAM ADDRESS] in Projects...Options...User...After Build/Rebuild section of the uVision project.
+
+
 ## Adding a new project
 For adding new targets start from template and use these docs...
 
@@ -35,4 +38,3 @@ Check out the issue tracker.
 - Create a test
 - Document how to use
 - Document how to contribute
-  

--- a/scripts/generate_blobs.py
+++ b/scripts/generate_blobs.py
@@ -30,12 +30,14 @@ from flash_algo import PackFlashAlgo
 BLOB_HEADER = '0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,'
 HEADER_SIZE = 0x20
 
+def str_to_num(val):
+    return int(val,0)  #convert string to number and automatically handle hex conversion
 
 def main():
     parser = argparse.ArgumentParser(description="Blob generator")
     parser.add_argument("elf_path", help="Elf, axf, or flm to extract "
                         "flash algo from")
-    parser.add_argument("--blob_start", default=0x20000000, help="Starting "
+    parser.add_argument("--blob_start", default=0x20000000, type=str_to_num, help="Starting "
                         "address of the flash blob. Used only for DAPLink.")
     args = parser.parse_args()
 


### PR DESCRIPTION
Fixes ability to pass in string representing hex number.  Should work with decimal number too.

Added details in readme.

I tested this and it is working.  

(sorry for the line ending issues.  a couple extra benign changes crept in.  any tips on avoiding that are appreciated.)  