### PR TITLE
Update flash_blob.py to gather a list of all sector start addresses and their size

### DIFF
--- a/scripts/c_blob.tmpl
+++ b/scripts/c_blob.tmpl
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+// This is a list of all flash sectors 
+static const uint16_t flash_sectors[] = {
+{%- for start, size  in algo.all_sectors %}
+    {{ "0x%x, 0x%x" % (start + algo.flash_start, size) }}, 
+{%- endfor %}
+};
+
 static const uint32_t {{name}}_flash_prog_blob[] = {
     {{prog_header}}
     {{algo.format_algo_data(4, 8, "c")}}

--- a/scripts/c_blob.tmpl
+++ b/scripts/c_blob.tmpl
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-// This is a list of all flash sectors 
-static const uint16_t flash_sectors[] = {
-{%- for start, size  in algo.all_sectors %}
-    {{ "0x%x, 0x%x" % (start + algo.flash_start, size) }}, 
-{%- endfor %}
-};
-
 static const uint32_t {{name}}_flash_prog_blob[] = {
     {{prog_header}}
     {{algo.format_algo_data(4, 8, "c")}}
 };
+
+static const uint32_t sectors_info[] = {
+{%- for start, size  in algo.sector_sizes %}
+    {{ "0x%08x, 0x%08x" % (start + algo.flash_start, size) }}, 
+{%- endfor %}
+};
+
+static const uint32_t flash_start = {{"0x%08x" % algo.flash_start}};
+static const uint32_t flash_size = {{"0x%08x" % algo.flash_size}};
 
 static const program_target_t flash = {
     {{'0x%08x' % (algo.symbols['Init'] + header_size + entry)}}, // Init

--- a/scripts/c_blob.tmpl
+++ b/scripts/c_blob.tmpl
@@ -19,14 +19,23 @@ static const uint32_t {{name}}_flash_prog_blob[] = {
     {{algo.format_algo_data(4, 8, "c")}}
 };
 
+// Start address of flash
+static const uint32_t flash_start = {{"0x%08x" % algo.flash_start}};
+// Size of flash
+static const uint32_t flash_size = {{"0x%08x" % algo.flash_size}};
+
+/**
+* List of start and size for each size of flash sector - even indexes are start, odd are size
+* The size will apply to all sectors between the listed address and the next address
+* in the list.
+* The last pair in the list will have sectors starting at that address and ending
+* at address flash_start + flash_size.
+*/
 static const uint32_t sectors_info[] = {
 {%- for start, size  in algo.sector_sizes %}
-    {{ "0x%08x, 0x%08x" % (start + algo.flash_start, size) }}, 
+    {{ "0x%08x, 0x%08x" % (start + algo.flash_start, size) }},
 {%- endfor %}
 };
-
-static const uint32_t flash_start = {{"0x%08x" % algo.flash_start}};
-static const uint32_t flash_size = {{"0x%08x" % algo.flash_size}};
 
 static const program_target_t flash = {
     {{'0x%08x' % (algo.symbols['Init'] + header_size + entry)}}, // Init
@@ -50,4 +59,3 @@ static const program_target_t flash = {
     {{name}}_flash_prog_blob,           // address of prog_blob
     {{'0x%08x' % algo.page_size}}       // ram_to_flash_bytes_to_be_written
 };
-

--- a/scripts/flash_algo.py
+++ b/scripts/flash_algo.py
@@ -80,7 +80,6 @@ class PackFlashAlgo(object):
         self.flash_size = self.flash_info.size
         self.page_size = self.flash_info.page_size
         self.sector_sizes = self.flash_info.sector_info_list
-        self.all_sectors = self.flash_info.all_sectors
 
         symbols = {}
         symbols.update(_extract_symbols(self.elf, self.REQUIRED_SYMBOLS))
@@ -113,7 +112,9 @@ class PackFlashAlgo(object):
     def format_algo_data(self, spaces, group_size, fmt):
         """"
         Return a string representing algo_data suitable for use in a template
+
         The string is intended for use in a template.
+
         :param spaces: The number of leading spaces for each line
         :param group_size: number of elements per line (element type
             depends of format)
@@ -269,7 +270,6 @@ class PackFlashInfo(object):
         self.prog_timeout_ms = values[8]
         self.erase_timeout_ms = values[9]
 
-        self.all_sectors = []
         sector_gen = self._sector_and_sz_itr(elf_simple,
                                              info_start + info_size)
         self.sector_info_list = list(sector_gen)
@@ -293,25 +293,13 @@ class PackFlashInfo(object):
         return desc
 
     def _sector_and_sz_itr(self, elf_simple, data_start):
-        """Iterator which returns starting address and sector size
-           Also generates a list of all sector starting addresses followed by size
-        """
+        """Iterator which returns starting address and sector size"""
         for entry_start in count(data_start, self.FLASH_SECTORS_STRUCT_SIZE):
             data = elf_simple.read(entry_start, self.FLASH_SECTORS_STRUCT_SIZE)
             size, start = struct.unpack(self.FLASH_SECTORS_STRUCT, data)
             start_and_size = start, size
-            if len(self.all_sectors) > 0:
-                # Find the previous sector start and size
-                prev_start, prev_size = self.all_sectors[-1]
-                # Fill in all sectors between the previously listed sector up to the current sector
-                for new_start in range(prev_start+prev_size, start, prev_size):
-                    if not((new_start+prev_size) > self.size):
-                        self.all_sectors.append((new_start, prev_size))
-                    else:
-                        break
             if start_and_size == (self.SECTOR_END, self.SECTOR_END):
                 return
-            self.all_sectors.append(start_and_size)
             yield start_and_size
 
 


### PR DESCRIPTION
This change updates `flash_blob.py` such that it will calculate **all** sector addresses and their sizes for a given target. Target FLM files currently define their sectors like so:
Address A | Size A
Address B | Size B

Where it is implied that all sectors between address A and B have the same size (size A). This change calculates all sector addresses and sizes between two listings. These values are written to `c_blob.c` as a new variable `flash_sectors`. This variable is a list of `uint32_t` formatted such that the first element is a sector address and the next element is its size, the second element is a sector address and the next element is its size, and so on. 

@sg- 