### PR TITLE
Restore pyOCD compatible template for generate_blobs.py

### DIFF
--- a/scripts/py_blob_orig.tmpl
+++ b/scripts/py_blob_orig.tmpl
@@ -1,0 +1,52 @@
+"""
+ Flash OS Routines (Automagically Generated)
+ Copyright (c) 2017-2018 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+flash_algo = {
+    'load_address' : {{'0x%08x' % entry}},
+
+    # Flash algorithm as a hex string
+    'instructions': [
+    {{prog_header}}
+    {{algo.format_algo_data(4, 8, "c")}}
+    ],
+
+    # Relative function addresses
+    'pc_init': {{'0x%08x' % (algo.symbols['Init'] + header_size + entry)}},
+    'pc_unInit': {{'0x%08x' % (algo.symbols['UnInit'] + header_size + entry)}},
+    'pc_program_page': {{'0x%08x' % (algo.symbols['ProgramPage'] + header_size + entry)}},
+    'pc_erase_sector': {{'0x%08x' % (algo.symbols['EraseSector'] + header_size + entry)}},
+    'pc_eraseAll': {{'0x%08x' % (algo.symbols['EraseChip'] + header_size + entry)}},
+
+    'static_base' : {{'0x%08x' % entry}} + {{'0x%08x' % header_size}} + {{'0x%08x' % algo.rw_start}},
+    'begin_stack' : {{'0x%08x' % stack_pointer}},
+    'begin_data' : {{'0x%08x' % entry}} + 0x1000,
+    'page_size' : {{'0x%x' % algo.page_size}},
+    'analyzer_supported' : False,
+    'analyzer_address' : 0x00000000,
+    'page_buffers' : [{{'0x%08x' % (entry + 4096)}}, {{'0x%08x' % (entry + 4096 + algo.page_size)}}],   # Enable double buffering
+    'min_program_length' : {{'0x%x' % algo.page_size}},
+
+    # Flash information
+    'flash_start': {{'0x%x' % algo.flash_start}},
+    'flash_size': {{'0x%x' % algo.flash_size}},
+    'sector_sizes': (
+    {%- for start, size  in algo.sector_sizes %}
+        {{ "(0x%x, 0x%x)" % (start, size) }},
+    {%- endfor %}
+    )
+}
+


### PR DESCRIPTION
Created a new `py_blob_orig.tmpl` that is compatible with pyOCD v~0.10.0. The future-facing `py_blob.tmpl` is retained.

Additional change: `generate_blob.py` computes SP from algo sizes instead of using a fixed value.